### PR TITLE
fix:部署在vercel，cleanUrls配置无效

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
按照原来的方式部署在vercel后cleanUrls功能并没有开启，根据[vitepress文档](https://vitepress.dev/guide/routing)  和[vercel](https://vercel.com/docs/projects/project-configuration#cleanurls) 得知，需要在根目录添加vercel.json 配置cleanUrls。
